### PR TITLE
Fix port must be string issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "name": "multi-api",
     "alias": "multi-api.now.sh",
     "env": {
-      "PORT": 8000,
+      "PORT": "8000",
       "DB": "@db",
       "CSE_CX": "@csecx",
       "CSE_KEY": "@csekey"


### PR DESCRIPTION
The port configuration for now in package.json was a number, but it should be a string. So, this pull request fixes that.